### PR TITLE
Adding support for new gsenha-api behavior

### DIFF
--- a/gsenha/manager.py
+++ b/gsenha/manager.py
@@ -87,11 +87,10 @@ class PasswordManager(object):
 
     def _decode_b64(self, a_str):
         # If string % 4 -add back '='
-        l_str = a_str.decode()
         l_mod = len(a_str) % 4
         if l_mod:
-            l_str += '=' * (4 - l_mod)
-        return (base64.urlsafe_b64decode(l_str)).decode('utf-8')
+            a_str += '=' * (4 - l_mod)
+        return (base64.urlsafe_b64decode(a_str)).decode('utf-8')
 
     def get_passwords(self, folder, *names):
         return_passwords = dict()

--- a/gsenha/manager.py
+++ b/gsenha/manager.py
@@ -85,15 +85,31 @@ class PasswordManager(object):
         raw_cipher_data = base64.b64decode(value)
         return str(self._rsa_verifier.decrypt(raw_cipher_data, padding.PKCS1v15()).decode('utf-8'))
 
+    def _decode_b64(self, a_str):
+        # If string % 4 -add back '='
+        l_str = a_str.decode()
+        l_mod = len(a_str) % 4
+        if l_mod:
+            l_str += '=' * (4 - l_mod)
+        return (base64.urlsafe_b64decode(l_str)).decode('utf-8')
+
     def get_passwords(self, folder, *names):
         return_passwords = dict()
         for name in names:
             password = self._get_password(folder, name)
             if password:
-                return_passwords[name] = {
-                    'url': self._decrypt(password['url']),
-                    'login': self._decrypt(password['login']),
-                    'password': self._decrypt(password['passwd']),
-                    'description': self._decrypt(password['description']),
-                }
+                if password['vault']:
+                    return_passwords[name] = {
+                        'url': self._decode_b64(password['url']),
+                        'login': self._decode_b64(password['login']),
+                        'password': self._decode_b64(password['passwd']),
+                        'description': self._decode_b64(password['description']),
+                    }
+                else:
+                    return_passwords[name] = {
+                        'url': self._decrypt(password['url']),
+                        'login': self._decrypt(password['login']),
+                        'password': self._decrypt(password['passwd']),
+                        'description': self._decrypt(password['description']),
+                    }
         return return_passwords

--- a/gsenha/manager.py
+++ b/gsenha/manager.py
@@ -98,7 +98,7 @@ class PasswordManager(object):
         for name in names:
             password = self._get_password(folder, name)
             if password:
-                if password['vault']:
+                if password.get('vault'):
                     return_passwords[name] = {
                         'url': self._decode_b64(password['url']),
                         'login': self._decode_b64(password['login']),

--- a/tests/test_password_manager.py
+++ b/tests/test_password_manager.py
@@ -112,12 +112,40 @@ class PasswordManagerTest(TestCase):
                 'login': encrypt_text('b'),
                 'passwd': encrypt_text('c'),
                 'description': encrypt_text('d'),
+                'vault': False
             }
         }
         mock_post.return_value = mock_response
 
         passwords = pm.get_passwords('folder-name', 'password-name')
 
+        self.assertEqual(passwords['password-name']['url'], 'a')
+        self.assertEqual(passwords['password-name']['login'], 'b')
+        self.assertEqual(passwords['password-name']['password'], 'c')
+        self.assertEqual(passwords['password-name']['description'], 'd')
+
+    @patch.object(PasswordManager, '_get_token', new=lambda x: 'my-fake-token')
+    @patch('requests.post')
+    def test_gets_passwords_correctly_vault_true(self, mock_post):
+        pm = PasswordManager(key='tests/fixtures/privkey.pem')
+
+        def b64_encode(text):
+            return base64.b64encode(bytes(text, 'utf-8'))
+
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            'status': 'success',
+            'password': {
+                'url': b64_encode('a'),
+                'login': b64_encode('b'),
+                'passwd': b64_encode('c'),
+                'description': b64_encode('d'),
+                'vault': True
+            }
+        }
+        mock_post.return_value = mock_response
+
+        passwords = pm.get_passwords('folder-name', 'password-name')
         self.assertEqual(passwords['password-name']['url'], 'a')
         self.assertEqual(passwords['password-name']['login'], 'b')
         self.assertEqual(passwords['password-name']['password'], 'c')

--- a/tests/test_password_manager.py
+++ b/tests/test_password_manager.py
@@ -130,7 +130,7 @@ class PasswordManagerTest(TestCase):
         pm = PasswordManager(key='tests/fixtures/privkey.pem')
 
         def b64_encode(text):
-            return base64.b64encode(bytes(text, 'utf-8'))
+            return base64.b64encode(bytes(text, 'utf-8')).decode()
 
         mock_response = Mock()
         mock_response.json.return_value = {


### PR DESCRIPTION
Gsenha-api changed its behavior in how it stores sensitive data.  A private key isn't necessary anymore, since gsenha-api is using [Vault](https://www.vaultproject.io/) as a secure backend storage.

As we can't update all password to the new backend storage we added a value in the response indicating if it is necessary to decrypt data using a private key or simply base64 decode.

In this MR we are checking if it is an old password or new one, and process according. 